### PR TITLE
Unnecessary escape in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ RegExp.escape("Buy it. use it. break it. fix it.") // "Buy it\. use it\. break i
 RegExp.escape("(*.*)"); // "\(\*\.\*\)"
 RegExp.escape("｡^･ｪ･^｡") // "｡\^･ｪ･\^｡"
 RegExp.escape("😊 *_* +_+ ... 👍"); // "😊 \*_\* \+_\+ \.\.\. 👍"
-RegExp.escape("\d \D (?:)"); // "\\d \\D \(\?\:\)"
+RegExp.escape("\d \D (?:)"); // "\\d \\D \(\?:\)"
 ```
 
 ### Template tag function


### PR DESCRIPTION
The colon in the last line of the example shows as having been escaped but would not (and does not need to) be under the proposal.